### PR TITLE
Upgrade terraform templates to tf v0.12 syntax

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -14,7 +14,7 @@
 ---
 packversion: 1
 name: google-cloud-services
-version: 0.1.0
+version: 0.1.1
 metadata:
   author: Google LLC
 platforms:
@@ -24,14 +24,14 @@ platforms:
   arch: amd64
 terraform_binaries:
 - name: terraform
-  version: 0.11.9
-  source: https://github.com/hashicorp/terraform/archive/v0.11.9.zip
+  version: 0.12.7
+  source: https://github.com/hashicorp/terraform/archive/v0.12.7.zip
 - name: terraform-provider-google
-  version: 1.20.0
-  source: https://github.com/terraform-providers/terraform-provider-google/archive/v1.20.0.zip
+  version: 2.14.0
+  source: https://github.com/terraform-providers/terraform-provider-google/archive/v2.14.0.zip
 - name: terraform-provider-null
-  version: 2.1.0
-  source: https://github.com/terraform-providers/terraform-provider-null/archive/v2.1.0.zip
+  version: 2.1.2
+  source: https://github.com/terraform-providers/terraform-provider-null/archive/v2.1.2.zip
 service_definitions:
 - services/google-bigquery.yml
 - services/google-bigtable.yml

--- a/services/google-bigquery.yml
+++ b/services/google-bigquery.yml
@@ -53,17 +53,27 @@ provision:
     overwrite: true
     type: "object"
   template: |+
-    variable labels {type = "map"}
-    variable location {type = "string"}
-    variable name {type = "string"}
-
-    resource "google_bigquery_dataset" "instance" {
-      dataset_id  = "${var.name}"
-      location    = "${var.location}"
-      labels      = "${var.labels}"
+    variable "labels" {
+      type = map(string)
     }
 
-    output dataset_id {value = "${google_bigquery_dataset.instance.dataset_id}"}
+    variable "location" {
+      type = string
+    }
+
+    variable "name" {
+      type = string
+    }
+
+    resource "google_bigquery_dataset" "instance" {
+      dataset_id = var.name
+      location   = var.location
+      labels     = var.labels
+    }
+
+    output "dataset_id" {
+      value = google_bigquery_dataset.instance.dataset_id
+    }
   outputs:
   - required: true
     field_name: dataset_id
@@ -97,29 +107,51 @@ bind:
     overwrite: true
     type: ""
   template: |
-    variable role {type = "string"}
-    variable service_account_display_name {type = "string"}
-    variable service_account_name {type = "string"}
+    variable "role" {
+      type = string
+    }
+
+    variable "service_account_display_name" {
+      type = string
+    }
+
+    variable "service_account_name" {
+      type = string
+    }
 
     resource "google_service_account" "account" {
-      account_id = "${var.service_account_name}"
-      display_name = "${var.service_account_name}"
+      account_id   = var.service_account_name
+      display_name = var.service_account_name
     }
 
     resource "google_service_account_key" "key" {
-      service_account_id = "${google_service_account.account.name}"
+      service_account_id = google_service_account.account.name
     }
 
     resource "google_project_iam_member" "instance" {
-      role    = "roles/${var.role}"
-      member  = "serviceAccount:${google_service_account.account.email}"
+      role   = "roles/${var.role}"
+      member = "serviceAccount:${google_service_account.account.email}"
     }
 
-    output Email {value = "${google_service_account.account.email}"}
-    output Name {value = "${google_service_account.account.display_name}"}
-    output PrivateKeyData {value = "${google_service_account_key.key.private_key}"}
-    output ProjectId {value = "${google_service_account.account.project}"}
-    output UniqueId {value = "${google_service_account.account.unique_id}"}
+    output "Email" {
+      value = google_service_account.account.email
+    }
+
+    output "Name" {
+      value = google_service_account.account.display_name
+    }
+
+    output "PrivateKeyData" {
+      value = google_service_account_key.key.private_key
+    }
+
+    output "ProjectId" {
+      value = google_service_account.account.project
+    }
+
+    output "UniqueId" {
+      value = google_service_account.account.unique_id
+    }
   outputs:
   - required: true
     field_name: Email

--- a/services/google-bigtable.yml
+++ b/services/google-bigtable.yml
@@ -81,27 +81,46 @@ provision:
       minimum: 1
   computed_inputs: []
   template: |+
-    variable cluster_id {type = "string"}
-    variable display_name {type = "string"}
-    variable name {type = "string"}
-    variable num_nodes {type = "string"}
-    variable storage_type {type = "string"}
-    variable zone {type = "string"}
+    variable "cluster_id" {
+      type = string
+    }
+
+    variable "display_name" {
+      type = string
+    }
+
+    variable "name" {
+      type = string
+    }
+
+    variable "num_nodes" {
+      type = string
+    }
+
+    variable "storage_type" {
+      type = string
+    }
+
+    variable "zone" {
+      type = string
+    }
 
     resource "google_bigtable_instance" "instance" {
-      name          = "${var.name}"
+      name          = var.name
       instance_type = "PRODUCTION"
-      display_name  = "${var.display_name}"
+      display_name  = var.display_name
 
       cluster {
-        cluster_id   = "${var.cluster_id}"
-        zone         = "${var.zone}"
-        num_nodes    = "${var.num_nodes}"
-        storage_type = "${var.storage_type}"
+        cluster_id   = var.cluster_id
+        zone         = var.zone
+        num_nodes    = var.num_nodes
+        storage_type = var.storage_type
       }
     }
 
-    output instance_id {value = "${var.name}"}
+    output "instance_id" {
+      value = var.name
+    }
   outputs:
   - field_name: instance_id
     required: true
@@ -130,28 +149,47 @@ bind:
     overwrite: true
     type: ""
   template: |
-    variable role {type = "string"}
-    variable service_account_name {type = "string"}
+    variable "role" {
+      type = string
+    }
+
+    variable "service_account_name" {
+      type = string
+    }
 
     resource "google_service_account" "account" {
-      account_id = "${var.service_account_name}"
-      display_name = "${var.service_account_name}"
+      account_id   = var.service_account_name
+      display_name = var.service_account_name
     }
 
     resource "google_service_account_key" "key" {
-      service_account_id = "${google_service_account.account.name}"
+      service_account_id = google_service_account.account.name
     }
 
     resource "google_project_iam_member" "instance" {
-      role    = "roles/${var.role}"
-      member  = "serviceAccount:${google_service_account.account.email}"
+      role   = "roles/${var.role}"
+      member = "serviceAccount:${google_service_account.account.email}"
     }
 
-    output Email {value = "${google_service_account.account.email}"}
-    output Name {value = "${google_service_account.account.display_name}"}
-    output PrivateKeyData {value = "${google_service_account_key.key.private_key}"}
-    output ProjectId {value = "${google_service_account.account.project}"}
-    output UniqueId {value = "${google_service_account.account.unique_id}"}
+    output "Email" {
+      value = google_service_account.account.email
+    }
+
+    output "Name" {
+      value = google_service_account.account.display_name
+    }
+
+    output "PrivateKeyData" {
+      value = google_service_account_key.key.private_key
+    }
+
+    output "ProjectId" {
+      value = google_service_account.account.project
+    }
+
+    output "UniqueId" {
+      value = google_service_account.account.unique_id
+    }
   outputs:
   - required: true
     field_name: Email

--- a/services/google-cloudsql-mysql.yml
+++ b/services/google-cloudsql-mysql.yml
@@ -163,93 +163,139 @@ provision:
     type: object
     overwrite: true
   template: |+
-    variable failover_enabled {type = "string"}
-    variable instance_name {type = "string"}
-    variable database_version {type = "string"}
-    variable region {type = "string"}
-    variable tier {type = "string"}
-    variable disk_size {type = "string"}
-    variable disk_autoresize {type = "string"}
-    variable disk_type {type = "string"}
-    variable maintenance_window_day {type = "string"}
-    variable maintenance_window_hour {type = "string"}
-    variable backup_enabled {type = "string"}
-    variable backup_start_time {type = "string"}
-    variable backup_binary_log_enabled {type = "string"}
-    variable authorized_networks {type = "string"}
-    variable replication_type {type = "string"}
+    variable "failover_enabled" {
+      type = string
+    }
 
-    variable labels {type = "map"}
-    variable database_name {type = "string"}
+    variable "instance_name" {
+      type = string
+    }
+
+    variable "database_version" {
+      type = string
+    }
+
+    variable "region" {
+      type = string
+    }
+
+    variable "tier" {
+      type = string
+    }
+
+    variable "disk_size" {
+      type = string
+    }
+
+    variable "disk_autoresize" {
+      type = string
+    }
+
+    variable "disk_type" {
+      type = string
+    }
+
+    variable "maintenance_window_day" {
+      type = string
+    }
+
+    variable "maintenance_window_hour" {
+      type = string
+    }
+
+    variable "backup_enabled" {
+      type = string
+    }
+
+    variable "backup_start_time" {
+      type = string
+    }
+
+    variable "backup_binary_log_enabled" {
+      type = string
+    }
+
+    variable "authorized_networks" {
+      type = string
+    }
+
+    variable "replication_type" {
+      type = string
+    }
+
+    variable "labels" {
+      type = map(string)
+    }
+
+    variable "database_name" {
+      type = string
+    }
 
     locals {
-      authorized_networks_list = "${split(",", var.authorized_networks)}"
+      authorized_networks_list = split(",", var.authorized_networks)
     }
 
     data "null_data_source" "allowed_networks" {
-      count  = "${length(local.authorized_networks_list)}"
+      count = length(local.authorized_networks_list)
 
       inputs = {
-        value = "${local.authorized_networks_list[count.index]}"
+        value = local.authorized_networks_list[count.index]
       }
     }
 
-
     resource "google_sql_database_instance" "master" {
-      database_version  = "${var.database_version}"
-      name              = "${var.instance_name}"
-      region            = "${var.region}"
+      database_version = var.database_version
+      name             = var.instance_name
+      region           = var.region
 
       settings {
-        tier              = "${var.tier}"
-        disk_autoresize   = "${var.disk_autoresize}"
-        disk_size         = "${var.disk_size}"
-        disk_type         = "${var.disk_type}"
-        replication_type  = "${var.replication_type}"
-        user_labels       = "${var.labels}"
+        tier             = var.tier
+        disk_autoresize  = var.disk_autoresize
+        disk_size        = var.disk_size
+        disk_type        = var.disk_type
+        replication_type = var.replication_type
+        user_labels      = var.labels
 
         backup_configuration {
-          binary_log_enabled  = "${var.backup_binary_log_enabled}"
-          enabled             = "${var.backup_enabled}"
-          start_time          = "${var.backup_start_time}"
+          binary_log_enabled = var.backup_binary_log_enabled
+          enabled            = var.backup_enabled
+          start_time         = var.backup_start_time
         }
 
         ip_configuration {
-          ipv4_enabled  = "true"
-          require_ssl   = "true"
-
+          ipv4_enabled = "true"
+          require_ssl  = "true"
           # authorized_networks = [
           #   "${data.null_data_source.allowed_networks.*.outputs}",
           # ]
         }
 
         maintenance_window {
-          day   = "${var.maintenance_window_day}"
-          hour  = "${var.maintenance_window_hour}"
+          day  = var.maintenance_window_day
+          hour = var.maintenance_window_hour
         }
       }
     }
 
     resource "google_sql_database_instance" "failover" {
-      count = "${var.failover_enabled == "true" ? 1 : 0}"
+      count = var.failover_enabled == "true" ? 1 : 0
 
-      database_version  = "${var.database_version}"
-      name              = "${var.instance_name}-failover"
-      region            = "${var.region}"
+      database_version = var.database_version
+      name             = "${var.instance_name}-failover"
+      region           = var.region
 
-      master_instance_name = "${google_sql_database_instance.master.name}"
+      master_instance_name = google_sql_database_instance.master.name
 
       settings {
-        tier              = "${var.tier}"
-        disk_autoresize   = "${var.disk_autoresize}"
-        disk_size         = "${var.disk_size}"
-        disk_type         = "${var.disk_type}"
-        user_labels       = "${var.labels}"
+        tier            = var.tier
+        disk_autoresize = var.disk_autoresize
+        disk_size       = var.disk_size
+        disk_type       = var.disk_type
+        user_labels     = var.labels
 
         ip_configuration {
-          ipv4_enabled  = "true"
-          require_ssl   = "true"
-
+          ipv4_enabled = "true"
+          require_ssl  = "true"
           # authorized_networks = [
           #   "${data.null_data_source.allowed_networks.*.outputs}",
           # ]
@@ -257,18 +303,26 @@ provision:
       }
 
       replica_configuration {
-        failover_target      = "true"
+        failover_target = "true"
       }
     }
 
     resource "google_sql_database" "db" {
-      name      = "${var.database_name}"
-      instance  = "${google_sql_database_instance.master.name}"
+      name     = var.database_name
+      instance = google_sql_database_instance.master.name
     }
 
-    output database_name {value = "${var.database_name}"}
-    output host {value = "${google_sql_database_instance.master.first_ip_address}"}
-    output instance_name {value = "${var.instance_name}"}
+    output "database_name" {
+      value = var.database_name
+    }
+
+    output "host" {
+      value = google_sql_database_instance.master.first_ip_address
+    }
+
+    output "instance_name" {
+      value = var.instance_name
+    }
   outputs:
   - required: true
     field_name: database_name
@@ -345,30 +399,51 @@ bind:
     type: "string"
   template: |
     # SSL cert to connect through the MySQL proxy
-    variable certname {type = "string"}
-    variable instance_name {type = "string"}
-
-    resource "google_sql_ssl_cert" "client_cert" {
-      common_name = "${var.certname}"
-      instance    = "${var.instance_name}"
+    variable "certname" {
+      type = string
     }
 
-    output CaCert {value = "${google_sql_ssl_cert.client_cert.server_ca_cert}"}
-    output ClientCert {value = "${google_sql_ssl_cert.client_cert.cert}"}
-    output ClientKey {value = "${google_sql_ssl_cert.client_cert.private_key}"}
-    output Sha1Fingerprint {value = "${google_sql_ssl_cert.client_cert.sha1_fingerprint}"}
+    variable "instance_name" {
+      type = string
+    }
+
+    resource "google_sql_ssl_cert" "client_cert" {
+      common_name = var.certname
+      instance    = var.instance_name
+    }
+
+    output "CaCert" {
+      value = google_sql_ssl_cert.client_cert.server_ca_cert
+    }
+
+    output "ClientCert" {
+      value = google_sql_ssl_cert.client_cert.cert
+    }
+
+    output "ClientKey" {
+      value = google_sql_ssl_cert.client_cert.private_key
+    }
+
+    output "Sha1Fingerprint" {
+      value = google_sql_ssl_cert.client_cert.sha1_fingerprint
+    }
 
     # Service account to connect to MySQL
-    variable service_account_name {type = "string"}
-    variable role {type = "string"}
+    variable "service_account_name" {
+      type = string
+    }
+
+    variable "role" {
+      type = string
+    }
 
     resource "google_service_account" "account" {
-      account_id = "${var.service_account_name}"
-      display_name = "${var.service_account_name}"
+      account_id   = var.service_account_name
+      display_name = var.service_account_name
     }
 
     resource "google_service_account_key" "key" {
-      service_account_id = "${google_service_account.account.name}"
+      service_account_id = google_service_account.account.name
     }
 
     resource "google_project_iam_member" "member" {
@@ -376,28 +451,60 @@ bind:
       member = "serviceAccount:${google_service_account.account.email}"
     }
 
-    output Name {value = "${google_service_account.account.display_name}"}
-    output Email {value = "${google_service_account.account.email}"}
-    output PrivateKeyData {value = "${google_service_account_key.key.private_key}"}
-    output ProjectId {value = "${google_service_account.account.project}"}
-    output UniqueId {value = "${google_service_account.account.unique_id}"}
-
-    # Username and password on the database instance
-    variable password {type = "string"}
-    variable username {type = "string"}
-
-    resource "google_sql_user" "user" {
-      name     = "${var.username}"
-      instance = "${var.instance_name}"
-      password = "${var.password}"
+    output "Name" {
+      value = google_service_account.account.display_name
     }
 
-    output Username {value = "${var.username}"}
-    output Password {value = "${var.password}"}
+    output "Email" {
+      value = google_service_account.account.email
+    }
 
-    variable database_name {type = "string"}
-    variable host {type = "string"}
-    output uri {value = "mysql://${urlencode(var.username)}:${urlencode(var.password)}@${urlencode(var.host)}/${urlencode(var.database_name)}?ssl_mode=required"}
+    output "PrivateKeyData" {
+      value = google_service_account_key.key.private_key
+    }
+
+    output "ProjectId" {
+      value = google_service_account.account.project
+    }
+
+    output "UniqueId" {
+      value = google_service_account.account.unique_id
+    }
+
+    # Username and password on the database instance
+    variable "password" {
+      type = string
+    }
+
+    variable "username" {
+      type = string
+    }
+
+    resource "google_sql_user" "user" {
+      name     = var.username
+      instance = var.instance_name
+      password = var.password
+    }
+
+    output "Username" {
+      value = var.username
+    }
+
+    output "Password" {
+      value = var.password
+    }
+
+    variable "database_name" {
+      type = string
+    }
+
+    variable "host" {
+      type = string
+    }
+
+    output "uri" {
+      value = "mysql://${urlencode(var.username)}:${urlencode(var.password)}@${urlencode(var.host)}/${urlencode(var.database_name)}?ssl_mode=required"
+    }
   outputs:
   - required: true
     field_name: Email

--- a/services/google-dataflow.yml
+++ b/services/google-dataflow.yml
@@ -49,16 +49,21 @@ bind:
     overwrite: true
     type: string
   template: |
-    variable role {type = "string"}
-    variable service_account_name {type = "string"}
+    variable "role" {
+      type = string
+    }
+
+    variable "service_account_name" {
+      type = string
+    }
 
     resource "google_service_account" "account" {
-      account_id = "${var.service_account_name}"
-      display_name = "${var.service_account_name}"
+      account_id   = var.service_account_name
+      display_name = var.service_account_name
     }
 
     resource "google_service_account_key" "key" {
-      service_account_id = "${google_service_account.account.name}"
+      service_account_id = google_service_account.account.name
     }
 
     resource "google_project_iam_member" "member" {
@@ -66,11 +71,25 @@ bind:
       member = "serviceAccount:${google_service_account.account.email}"
     }
 
-    output Email {value = "${google_service_account.account.email}"}
-    output Name {value = "${google_service_account.account.display_name}"}
-    output PrivateKeyData {value = "${google_service_account_key.key.private_key}"}
-    output ProjectId {value = "${google_service_account.account.project}"}
-    output UniqueId {value = "${google_service_account.account.unique_id}"}
+    output "Email" {
+      value = google_service_account.account.email
+    }
+
+    output "Name" {
+      value = google_service_account.account.display_name
+    }
+
+    output "PrivateKeyData" {
+      value = google_service_account_key.key.private_key
+    }
+
+    output "ProjectId" {
+      value = google_service_account.account.project
+    }
+
+    output "UniqueId" {
+      value = google_service_account.account.unique_id
+    }
   outputs:
   - required: true
     field_name: Email

--- a/services/google-dataproc.yml
+++ b/services/google-dataproc.yml
@@ -81,41 +81,67 @@ provision:
     overwrite: true
     type: object
   template: |-
-    variable worker_machine_type {type = "string"}
-    variable master_machine_type {type = "string"}
-    variable worker_count {type = "string"}
-    variable master_count {type = "string"}
-    variable preemptible_count {type = "string"}
+    variable "worker_machine_type" {
+      type = string
+    }
 
-    variable name {type = "string"}
-    variable region {type = "string"}
-    variable labels {type = "map"}
+    variable "master_machine_type" {
+      type = string
+    }
+
+    variable "worker_count" {
+      type = string
+    }
+
+    variable "master_count" {
+      type = string
+    }
+
+    variable "preemptible_count" {
+      type = string
+    }
+
+    variable "name" {
+      type = string
+    }
+
+    variable "region" {
+      type = string
+    }
+
+    variable "labels" {
+      type = map(string)
+    }
 
     resource "google_dataproc_cluster" "cluster" {
-      name   = "${var.name}"
-      region = "${var.region}"
-      labels = "${var.labels}"
+      name   = var.name
+      region = var.region
+      labels = var.labels
 
       cluster_config {
         master_config {
-          num_instances = "${var.master_count}"
-          machine_type  = "${var.master_machine_type}"
+          num_instances = var.master_count
+          machine_type  = var.master_machine_type
         }
 
         worker_config {
-          num_instances = "${var.worker_count}"
-          machine_type  = "${var.worker_machine_type}"
+          num_instances = var.worker_count
+          machine_type  = var.worker_machine_type
         }
 
         preemptible_worker_config {
-          num_instances = "${var.preemptible_count}"
+          num_instances = var.preemptible_count
         }
       }
     }
 
-    output bucket_name {value = "${google_dataproc_cluster.cluster.cluster_config.0.bucket}"}
-    output name {value = "${google_dataproc_cluster.cluster.name}"}
+    output "bucket_name" {
+      value = google_dataproc_cluster.cluster.cluster_config[0].bucket
+    }
 
+    output "name" {
+      value = google_dataproc_cluster.cluster.name
+    }
   outputs:
   - required: true
     field_name: bucket_name
@@ -140,20 +166,25 @@ bind:
     default: ${instance.details["bucket_name"]}
     overwrite: true
   template: |-
-    variable service_account_name {type = "string"}
-    variable bucket {type = "string"}
+    variable "service_account_name" {
+      type = string
+    }
+
+    variable "bucket" {
+      type = string
+    }
 
     resource "google_service_account" "account" {
-      account_id = "${var.service_account_name}"
-      display_name = "${var.service_account_name}"
+      account_id   = var.service_account_name
+      display_name = var.service_account_name
     }
 
     resource "google_service_account_key" "key" {
-      service_account_id = "${google_service_account.account.name}"
+      service_account_id = google_service_account.account.name
     }
 
     resource "google_storage_bucket_iam_member" "member" {
-      bucket = "${var.bucket}"
+      bucket = var.bucket
       role   = "roles/storage.objectAdmin"
       member = "serviceAccount:${google_service_account.account.email}"
     }
@@ -163,11 +194,21 @@ bind:
       member = "serviceAccount:${google_service_account.account.email}"
     }
 
+    output "name" {
+      value = google_service_account.account.display_name
+    }
 
-    output "name" {value = "${google_service_account.account.display_name}"}
-    output "email" {value = "${google_service_account.account.email}"}
-    output "private_key" {value = "${google_service_account_key.key.private_key}"}
-    output "project_id" {value = "${google_service_account.account.project}"}
+    output "email" {
+      value = google_service_account.account.email
+    }
+
+    output "private_key" {
+      value = google_service_account_key.key.private_key
+    }
+
+    output "project_id" {
+      value = google_service_account.account.project
+    }
   outputs:
   - required: true
     field_name: email

--- a/services/google-datastore.yml
+++ b/services/google-datastore.yml
@@ -42,8 +42,13 @@ provision:
       pattern: ^[A-Za-z0-9_-]*$
   computed_inputs: []
   template: |-
-    variable namespace {type = "string"}
-    output namespace {value = "${var.namespace}"}
+    variable "namespace" {
+      type = string
+    }
+
+    output "namespace" {
+      value = var.namespace
+    }
   outputs:
   - field_name: namespace
     type: string
@@ -60,15 +65,17 @@ bind:
     overwrite: true
     type: string
   template: |
-    variable service_account_name {type = "string"}
+    variable "service_account_name" {
+      type = string
+    }
 
     resource "google_service_account" "account" {
-      account_id = "${var.service_account_name}"
-      display_name = "${var.service_account_name}"
+      account_id   = var.service_account_name
+      display_name = var.service_account_name
     }
 
     resource "google_service_account_key" "key" {
-      service_account_id = "${google_service_account.account.name}"
+      service_account_id = google_service_account.account.name
     }
 
     resource "google_project_iam_member" "member" {
@@ -76,11 +83,25 @@ bind:
       member = "serviceAccount:${google_service_account.account.email}"
     }
 
-    output Email {value = "${google_service_account.account.email}"}
-    output Name {value = "${google_service_account.account.display_name}"}
-    output PrivateKeyData {value = "${google_service_account_key.key.private_key}"}
-    output ProjectId {value = "${google_service_account.account.project}"}
-    output UniqueId {value = "${google_service_account.account.unique_id}"}
+    output "Email" {
+      value = google_service_account.account.email
+    }
+
+    output "Name" {
+      value = google_service_account.account.display_name
+    }
+
+    output "PrivateKeyData" {
+      value = google_service_account_key.key.private_key
+    }
+
+    output "ProjectId" {
+      value = google_service_account.account.project
+    }
+
+    output "UniqueId" {
+      value = google_service_account.account.unique_id
+    }
   outputs:
   - required: true
     field_name: Email

--- a/services/google-dialogflow.yml
+++ b/services/google-dialogflow.yml
@@ -42,15 +42,17 @@ bind:
     overwrite: true
     type: string
   template: |
-    variable service_account_name {type = "string"}
+    variable "service_account_name" {
+      type = string
+    }
 
     resource "google_service_account" "account" {
-      account_id = "${var.service_account_name}"
-      display_name = "${var.service_account_name}"
+      account_id   = var.service_account_name
+      display_name = var.service_account_name
     }
 
     resource "google_service_account_key" "key" {
-      service_account_id = "${google_service_account.account.name}"
+      service_account_id = google_service_account.account.name
     }
 
     resource "google_project_iam_member" "member" {
@@ -58,11 +60,25 @@ bind:
       member = "serviceAccount:${google_service_account.account.email}"
     }
 
-    output Email {value = "${google_service_account.account.email}"}
-    output Name {value = "${google_service_account.account.display_name}"}
-    output PrivateKeyData {value = "${google_service_account_key.key.private_key}"}
-    output ProjectId {value = "${google_service_account.account.project}"}
-    output UniqueId {value = "${google_service_account.account.unique_id}"}
+    output "Email" {
+      value = google_service_account.account.email
+    }
+
+    output "Name" {
+      value = google_service_account.account.display_name
+    }
+
+    output "PrivateKeyData" {
+      value = google_service_account_key.key.private_key
+    }
+
+    output "ProjectId" {
+      value = google_service_account.account.project
+    }
+
+    output "UniqueId" {
+      value = google_service_account.account.unique_id
+    }
   outputs:
   - required: true
     field_name: Email

--- a/services/google-firestore.yml
+++ b/services/google-firestore.yml
@@ -49,28 +49,47 @@ bind:
     overwrite: true
     type: "string"
   template: |
-    variable role {type = "string"}
-    variable service_account_name {type = "string"}
+    variable "role" {
+      type = string
+    }
+
+    variable "service_account_name" {
+      type = string
+    }
 
     resource "google_service_account" "account" {
-      account_id = "${var.service_account_name}"
-      display_name = "${var.service_account_name}"
+      account_id   = var.service_account_name
+      display_name = var.service_account_name
     }
 
     resource "google_service_account_key" "key" {
-      service_account_id = "${google_service_account.account.name}"
+      service_account_id = google_service_account.account.name
     }
 
     resource "google_project_iam_member" "member" {
-      role   = "${var.role}"
+      role   = var.role
       member = "serviceAccount:${google_service_account.account.email}"
     }
 
-    output Email {value = "${google_service_account.account.email}"}
-    output Name {value = "${google_service_account.account.display_name}"}
-    output PrivateKeyData {value = "${google_service_account_key.key.private_key}"}
-    output ProjectId {value = "${google_service_account.account.project}"}
-    output UniqueId {value = "${google_service_account.account.unique_id}"}
+    output "Email" {
+      value = google_service_account.account.email
+    }
+
+    output "Name" {
+      value = google_service_account.account.display_name
+    }
+
+    output "PrivateKeyData" {
+      value = google_service_account_key.key.private_key
+    }
+
+    output "ProjectId" {
+      value = google_service_account.account.project
+    }
+
+    output "UniqueId" {
+      value = google_service_account.account.unique_id
+    }
   outputs:
   - required: true
     field_name: Email

--- a/services/google-iam.yml
+++ b/services/google-iam.yml
@@ -48,34 +48,53 @@ bind:
     overwrite: true
     type: string
   template: |
-    variable service_account_name {type = "string"}
-    variable roles {type = "string"}
+    variable "service_account_name" {
+      type = string
+    }
+
+    variable "roles" {
+      type = string
+    }
 
     locals {
-      role_list = "${split(",", var.roles)}"
+      role_list = split(",", var.roles)
     }
 
     resource "google_service_account" "account" {
-      account_id = "${var.service_account_name}"
-      display_name = "${var.service_account_name}"
+      account_id   = var.service_account_name
+      display_name = var.service_account_name
     }
 
     resource "google_service_account_key" "key" {
-      service_account_id = "${google_service_account.account.name}"
+      service_account_id = google_service_account.account.name
     }
 
     resource "google_project_iam_member" "member" {
-      count  = "${length(local.role_list)}"
+      count = length(local.role_list)
 
-      role   = "${local.role_list[count.index]}"
+      role   = local.role_list[count.index]
       member = "serviceAccount:${google_service_account.account.email}"
     }
 
-    output name {value = "${google_service_account.account.display_name}"}
-    output email {value = "${google_service_account.account.email}"}
-    output private_key {value = "${google_service_account_key.key.private_key}"}
-    output project_id {value = "${google_service_account.account.project}"}
-    output roles {value = "${var.roles}"}
+    output "name" {
+      value = google_service_account.account.display_name
+    }
+
+    output "email" {
+      value = google_service_account.account.email
+    }
+
+    output "private_key" {
+      value = google_service_account_key.key.private_key
+    }
+
+    output "project_id" {
+      value = google_service_account.account.project
+    }
+
+    output "roles" {
+      value = var.roles
+    }
   outputs:
   - required: true
     field_name: email

--- a/services/google-ml-apis.yml
+++ b/services/google-ml-apis.yml
@@ -53,28 +53,47 @@ bind:
     overwrite: true
     type: "string"
   template: |
-    variable role {type = "string"}
-    variable service_account_name {type = "string"}
+    variable "role" {
+      type = string
+    }
+
+    variable "service_account_name" {
+      type = string
+    }
 
     resource "google_service_account" "account" {
-      account_id = "${var.service_account_name}"
-      display_name = "${var.service_account_name}"
+      account_id   = var.service_account_name
+      display_name = var.service_account_name
     }
 
     resource "google_service_account_key" "key" {
-      service_account_id = "${google_service_account.account.name}"
+      service_account_id = google_service_account.account.name
     }
 
     resource "google_project_iam_member" "member" {
-      role   = "${var.role}"
+      role   = var.role
       member = "serviceAccount:${google_service_account.account.email}"
     }
 
-    output Email {value = "${google_service_account.account.email}"}
-    output Name {value = "${google_service_account.account.display_name}"}
-    output PrivateKeyData {value = "${google_service_account_key.key.private_key}"}
-    output ProjectId {value = "${google_service_account.account.project}"}
-    output UniqueId {value = "${google_service_account.account.unique_id}"}
+    output "Email" {
+      value = google_service_account.account.email
+    }
+
+    output "Name" {
+      value = google_service_account.account.display_name
+    }
+
+    output "PrivateKeyData" {
+      value = google_service_account_key.key.private_key
+    }
+
+    output "ProjectId" {
+      value = google_service_account.account.project
+    }
+
+    output "UniqueId" {
+      value = google_service_account.account.unique_id
+    }
   outputs:
   - required: true
     field_name: Email

--- a/services/google-pubsub-topic.yml
+++ b/services/google-pubsub-topic.yml
@@ -46,17 +46,24 @@ provision:
     type: object
     overwrite: true
   template: |+
-    variable labels {type = "map"}
-    variable topic_name {type = "string"}
-
-    resource "google_pubsub_topic" "topic" {
-      name = "${var.topic_name}"
-      # TODO(josephlewis42): this isn't supported by Terraform at this time, but
-      # it is implemented by Magic Modules and is just waiting for a release.
-      # labels = "${var.labels}"
+    variable "labels" {
+      type = map(string)
     }
 
-    output topic_name {value = "${google_pubsub_topic.topic.name}"}
+    variable "topic_name" {
+      type = string
+    }
+
+    resource "google_pubsub_topic" "topic" {
+      name = var.topic_name
+      # TODO(josephlewis42): this isn't supported by Terraform at this time, but
+      # it is implemented by Magic Modules and is just waiting for a release.
+      # labels = var.labels
+    }
+
+    output "topic_name" {
+      value = google_pubsub_topic.topic.name
+    }
   outputs:
   - required: true
     field_name: topic_name
@@ -77,30 +84,48 @@ bind:
     default: ${instance.details["topic_name"]}
     overwrite: true
   template: |
-    variable service_account_name {type = "string"}
-    variable topic_name {type = "string"}
+    variable "service_account_name" {
+      type = string
+    }
+
+    variable "topic_name" {
+      type = string
+    }
 
     resource "google_service_account" "account" {
-      account_id = "${var.service_account_name}"
-      display_name = "${var.service_account_name}"
+      account_id   = var.service_account_name
+      display_name = var.service_account_name
     }
 
     resource "google_service_account_key" "key" {
-      service_account_id = "${google_service_account.account.name}"
+      service_account_id = google_service_account.account.name
     }
 
     resource "google_pubsub_topic_iam_member" "default" {
-      topic  = "${var.topic_name}"
+      topic  = var.topic_name
       role   = "roles/pubsub.editor"
       member = "serviceAccount:${google_service_account.account.email}"
     }
 
-    output Email {value = "${google_service_account.account.email}"}
-    output Name {value = "${google_service_account.account.display_name}"}
-    output PrivateKeyData {value = "${google_service_account_key.key.private_key}"}
-    output ProjectId {value = "${google_service_account.account.project}"}
-    output UniqueId {value = "${google_service_account.account.unique_id}"}
+    output "Email" {
+      value = google_service_account.account.email
+    }
 
+    output "Name" {
+      value = google_service_account.account.display_name
+    }
+
+    output "PrivateKeyData" {
+      value = google_service_account_key.key.private_key
+    }
+
+    output "ProjectId" {
+      value = google_service_account.account.project
+    }
+
+    output "UniqueId" {
+      value = google_service_account.account.unique_id
+    }
   outputs:
   - required: true
     field_name: Email

--- a/services/google-pubsub.yml
+++ b/services/google-pubsub.yml
@@ -67,44 +67,62 @@ provision:
     type: object
     overwrite: true
   template: |+
-    variable ack_deadline {type = "string"}
-    variable endpoint {type = "string"}
-    variable labels {type = "map"}
-    variable subscription_name {type = "string"}
-    variable topic_name {type = "string"}
+    variable "ack_deadline" {
+      type = string
+    }
+
+    variable "endpoint" {
+      type = string
+    }
+
+    variable "labels" {
+      type = map(string)
+    }
+
+    variable "subscription_name" {
+      type = string
+    }
+
+    variable "topic_name" {
+      type = string
+    }
 
     resource "google_pubsub_topic" "default" {
-      name = "${var.topic_name}"
+      name = var.topic_name
       # TODO(josephlewis42): this isn't supported by Terraform at this time, but
       # it is implemented by Magic Modules and is just waiting for a release.
-      # labels = "${var.labels}"
+      # labels = var.labels
     }
 
     resource "google_pubsub_subscription" "nopush" {
-      count = "${(length(var.subscription_name) > 0 && length(var.endpoint) == 0) ? 1 : 0}"
+      count = length(var.subscription_name) > 0 && length(var.endpoint) == 0 ? 1 : 0
 
-      name  = "${var.subscription_name}"
-      topic = "${google_pubsub_topic.default.name}"
+      name  = var.subscription_name
+      topic = google_pubsub_topic.default.name
 
-      ack_deadline_seconds = "${var.ack_deadline}"
+      ack_deadline_seconds = var.ack_deadline
     }
 
     resource "google_pubsub_subscription" "push" {
-      count = "${(length(var.subscription_name) > 0 && length(var.endpoint) != 0) ? 1 : 0}"
+      count = length(var.subscription_name) > 0 && length(var.endpoint) != 0 ? 1 : 0
 
-      name  = "${var.subscription_name}"
-      topic = "${google_pubsub_topic.default.name}"
+      name  = var.subscription_name
+      topic = google_pubsub_topic.default.name
 
-      ack_deadline_seconds = "${var.ack_deadline}"
+      ack_deadline_seconds = var.ack_deadline
 
       push_config {
-        push_endpoint = "${var.endpoint}"
+        push_endpoint = var.endpoint
       }
     }
 
-    output subscription_name {value = "${var.subscription_name}"}
-    output topic_name {value = "${var.topic_name}"}
+    output "subscription_name" {
+      value = var.subscription_name
+    }
 
+    output "topic_name" {
+      value = var.topic_name
+    }
   outputs:
   - field_name: subscription_name
     type: string
@@ -138,39 +156,63 @@ bind:
     default: ${instance.details["subscription_name"]}
     overwrite: true
   template: |
-    variable service_account_display_name {type = "string"}
-    variable service_account_name {type = "string"}
-    variable subscription_name {type = "string"}
-    variable topic_name {type = "string"}
+    variable "service_account_display_name" {
+      type = string
+    }
+
+    variable "service_account_name" {
+      type = string
+    }
+
+    variable "subscription_name" {
+      type = string
+    }
+
+    variable "topic_name" {
+      type = string
+    }
 
     resource "google_service_account" "account" {
-      account_id = "${var.service_account_name}"
-      display_name = "${var.service_account_name}"
+      account_id   = var.service_account_name
+      display_name = var.service_account_name
     }
 
     resource "google_service_account_key" "key" {
-      service_account_id = "${google_service_account.account.name}"
+      service_account_id = google_service_account.account.name
     }
 
     resource "google_pubsub_topic_iam_member" "default" {
-      topic  = "${var.topic_name}"
+      topic  = var.topic_name
       role   = "roles/pubsub.editor"
       member = "serviceAccount:${google_service_account.account.email}"
     }
 
     resource "google_pubsub_subscription_iam_member" "default" {
-      count        = "${length(var.subscription_name) > 0 ? 1 : 0}"
-      subscription = "${var.subscription_name}"
+      count        = length(var.subscription_name) > 0 ? 1 : 0
+      subscription = var.subscription_name
       role         = "roles/pubsub.editor"
       member       = "serviceAccount:${google_service_account.account.email}"
     }
 
-    output Email {value = "${google_service_account.account.email}"}
-    output Name {value = "${google_service_account.account.display_name}"}
-    output PrivateKeyData {value = "${google_service_account_key.key.private_key}"}
-    output ProjectId {value = "${google_service_account.account.project}"}
-    output UniqueId {value = "${google_service_account.account.unique_id}"}
+    output "Email" {
+      value = google_service_account.account.email
+    }
 
+    output "Name" {
+      value = google_service_account.account.display_name
+    }
+
+    output "PrivateKeyData" {
+      value = google_service_account_key.key.private_key
+    }
+
+    output "ProjectId" {
+      value = google_service_account.account.project
+    }
+
+    output "UniqueId" {
+      value = google_service_account.account.unique_id
+    }
   outputs:
   - required: true
     field_name: Email

--- a/services/google-redis.yml
+++ b/services/google-redis.yml
@@ -85,26 +85,49 @@ provision:
     overwrite: true
     type: object
   template: |-
-    variable service_tier { type = "string" }
-    variable authorized_network { type = "string" }
-    variable display_name { type = "string" }
-    variable instance_id { type = "string" }
-    variable region { type = "string" }
-    variable memory_size_gb { type = "string" }
-    variable labels { type = "map" }
+    variable "service_tier" {
+      type = string
+    }
+
+    variable "authorized_network" {
+      type = string
+    }
+
+    variable "display_name" {
+      type = string
+    }
+
+    variable "instance_id" {
+      type = string
+    }
+
+    variable "region" {
+      type = string
+    }
+
+    variable "memory_size_gb" {
+      type = string
+    }
+
+    variable "labels" {
+      type = map(string)
+    }
 
     data "google_compute_network" "default-network" {
       name = "default"
     }
 
     resource "google_redis_instance" "instance" {
-      name               = "${var.instance_id}"
-      tier               = "${var.service_tier}"
-      memory_size_gb     = "${var.memory_size_gb}"
-      display_name       = "${var.display_name}"
-      region             = "${var.region}"
-      authorized_network = "${coalesce(var.authorized_network, data.google_compute_network.default-network.self_link)}"
-      labels             = "${var.labels}"
+      name           = var.instance_id
+      tier           = var.service_tier
+      memory_size_gb = var.memory_size_gb
+      display_name   = var.display_name
+      region         = var.region
+      authorized_network = coalesce(
+        var.authorized_network,
+        data.google_compute_network.default-network.self_link,
+      )
+      labels = var.labels
 
       timeouts {
         create = "15m"
@@ -113,11 +136,25 @@ provision:
       }
     }
 
-    output memory_size_gb { value = "${google_redis_instance.instance.memory_size_gb}" }
-    output service_tier { value = "${google_redis_instance.instance.tier}" }
-    output redis_version { value = "${google_redis_instance.instance.redis_version}" }
-    output host { value = "${google_redis_instance.instance.host}" }
-    output port { value = "${google_redis_instance.instance.port}" }
+    output "memory_size_gb" {
+      value = google_redis_instance.instance.memory_size_gb
+    }
+
+    output "service_tier" {
+      value = google_redis_instance.instance.tier
+    }
+
+    output "redis_version" {
+      value = google_redis_instance.instance.redis_version
+    }
+
+    output "host" {
+      value = google_redis_instance.instance.host
+    }
+
+    output "port" {
+      value = google_redis_instance.instance.port
+    }
   outputs:
   - required: true
     field_name: memory_size_gb

--- a/services/google-spanner.yml
+++ b/services/google-spanner.yml
@@ -82,21 +82,37 @@ provision:
     overwrite: true
     type: object
   template: |+
-    variable display_name {type = "string"}
-    variable labels {type = "map"}
-    variable location {type = "string"}
-    variable name {type = "string"}
-    variable num_nodes {type = "string"}
-
-    resource "google_spanner_instance" "instance" {
-      name = "${var.name}"
-      config = "${var.location}"
-      display_name = "${var.display_name}"
-      num_nodes = "${var.num_nodes}"
-      labels = "${var.labels}"
+    variable "display_name" {
+      type = string
     }
 
-    output instance_id {value = "${google_spanner_instance.instance.name}"}
+    variable "labels" {
+      type = map(string)
+    }
+
+    variable "location" {
+      type = string
+    }
+
+    variable "name" {
+      type = string
+    }
+
+    variable "num_nodes" {
+      type = string
+    }
+
+    resource "google_spanner_instance" "instance" {
+      name         = var.name
+      config       = var.location
+      display_name = var.display_name
+      num_nodes    = var.num_nodes
+      labels       = var.labels
+    }
+
+    output "instance_id" {
+      value = google_spanner_instance.instance.name
+    }
   outputs:
   - required: true
     field_name: instance_id
@@ -131,31 +147,56 @@ bind:
     default: ${instance.details["instance_id"]}
     overwrite: true
   template: |
-    variable role {type = "string"}
-    variable service_account_display_name {type = "string"}
-    variable service_account_name {type = "string"}
-    variable instance_id {type = "string"}
+    variable "role" {
+      type = string
+    }
+
+    variable "service_account_display_name" {
+      type = string
+    }
+
+    variable "service_account_name" {
+      type = string
+    }
+
+    variable "instance_id" {
+      type = string
+    }
 
     resource "google_service_account" "account" {
-      account_id = "${var.service_account_name}"
-      display_name = "${var.service_account_name}"
+      account_id   = var.service_account_name
+      display_name = var.service_account_name
     }
 
     resource "google_service_account_key" "key" {
-      service_account_id = "${google_service_account.account.name}"
+      service_account_id = google_service_account.account.name
     }
 
     resource "google_spanner_instance_iam_member" "instance" {
-      instance  = "${var.instance_id}"
-      role      = "roles/${var.role}"
-      member    = "serviceAccount:${google_service_account.account.email}"
+      instance = var.instance_id
+      role     = "roles/${var.role}"
+      member   = "serviceAccount:${google_service_account.account.email}"
     }
 
-    output Email {value = "${google_service_account.account.email}"}
-    output Name {value = "${google_service_account.account.display_name}"}
-    output PrivateKeyData {value = "${google_service_account_key.key.private_key}"}
-    output ProjectId {value = "${google_service_account.account.project}"}
-    output UniqueId {value = "${google_service_account.account.unique_id}"}
+    output "Email" {
+      value = google_service_account.account.email
+    }
+
+    output "Name" {
+      value = google_service_account.account.display_name
+    }
+
+    output "PrivateKeyData" {
+      value = google_service_account_key.key.private_key
+    }
+
+    output "ProjectId" {
+      value = google_service_account.account.project
+    }
+
+    output "UniqueId" {
+      value = google_service_account.account.unique_id
+    }
   outputs:
   - required: true
     field_name: Email

--- a/services/google-stackdriver.yml
+++ b/services/google-stackdriver.yml
@@ -80,35 +80,57 @@ bind:
     overwrite: true
     type: string
   template: |
-    variable service_account_name {type = "string"}
-    variable roles {type = "string"}
+    variable "service_account_name" {
+      type = string
+    }
+
+    variable "roles" {
+      type = string
+    }
 
     locals {
-      role_list = "${split(",", var.roles)}"
+      role_list = split(",", var.roles)
     }
 
     resource "google_service_account" "account" {
-      account_id = "${var.service_account_name}"
-      display_name = "${var.service_account_name}"
+      account_id   = var.service_account_name
+      display_name = var.service_account_name
     }
 
     resource "google_service_account_key" "key" {
-      service_account_id = "${google_service_account.account.name}"
+      service_account_id = google_service_account.account.name
     }
 
     resource "google_project_iam_member" "member" {
-      count  = "${length(local.role_list)}"
+      count = length(local.role_list)
 
-      role   = "${local.role_list[count.index]}"
+      role   = local.role_list[count.index]
       member = "serviceAccount:${google_service_account.account.email}"
     }
 
-    output Email {value = "${google_service_account.account.email}"}
-    output Name {value = "${google_service_account.account.display_name}"}
-    output PrivateKeyData {value = "${google_service_account_key.key.private_key}"}
-    output ProjectId {value = "${google_service_account.account.project}"}
-    output UniqueId {value = "${google_service_account.account.unique_id}"}
-    output Roles {value = "${var.roles}"}
+    output "Email" {
+      value = google_service_account.account.email
+    }
+
+    output "Name" {
+      value = google_service_account.account.display_name
+    }
+
+    output "PrivateKeyData" {
+      value = google_service_account_key.key.private_key
+    }
+
+    output "ProjectId" {
+      value = google_service_account.account.project
+    }
+
+    output "UniqueId" {
+      value = google_service_account.account.unique_id
+    }
+
+    output "Roles" {
+      value = var.roles
+    }
   outputs:
   - required: true
     field_name: Email

--- a/services/google-storage.yml
+++ b/services/google-storage.yml
@@ -94,19 +94,32 @@ provision:
     overwrite: true
     type: object
   template: |+
-    variable labels { type = "map" }
-    variable location {type = "string"}
-    variable name {type = "string"}
-    variable storage_class {type = "string"}
-
-    resource "google_storage_bucket" "instance" {
-      name = "${var.name}"
-      location = "${var.location}"
-      storage_class = "${var.storage_class}"
-      labels = "${var.labels}"
+    variable "labels" {
+      type = map(string)
     }
 
-    output bucket_name {value = "${google_storage_bucket.instance.name}"}
+    variable "location" {
+      type = string
+    }
+
+    variable "name" {
+      type = string
+    }
+
+    variable "storage_class" {
+      type = string
+    }
+
+    resource "google_storage_bucket" "instance" {
+      name          = var.name
+      location      = var.location
+      storage_class = var.storage_class
+      labels        = var.labels
+    }
+
+    output "bucket_name" {
+      value = google_storage_bucket.instance.name
+    }
   outputs:
   - required: true
     field_name: bucket_name
@@ -143,31 +156,56 @@ bind:
     overwrite: true
     type: "string"
   template: |
-    variable role {type = "string"}
-    variable service_account_display_name {type = "string"}
-    variable service_account_name {type = "string"}
-    variable bucket_name {type="string"}
+    variable "role" {
+      type = string
+    }
+
+    variable "service_account_display_name" {
+      type = string
+    }
+
+    variable "service_account_name" {
+      type = string
+    }
+
+    variable "bucket_name" {
+      type = string
+    }
 
     resource "google_service_account" "account" {
-      account_id = "${var.service_account_name}"
-      display_name = "${var.service_account_name}"
+      account_id   = var.service_account_name
+      display_name = var.service_account_name
     }
 
     resource "google_service_account_key" "key" {
-      service_account_id = "${google_service_account.account.name}"
+      service_account_id = google_service_account.account.name
     }
 
     resource "google_storage_bucket_iam_member" "instance" {
-      bucket  = "${var.bucket_name}"
-      role    = "roles/${var.role}"
-      member  = "serviceAccount:${google_service_account.account.email}"
+      bucket = var.bucket_name
+      role   = "roles/${var.role}"
+      member = "serviceAccount:${google_service_account.account.email}"
     }
 
-    output Email {value = "${google_service_account.account.email}"}
-    output Name {value = "${google_service_account.account.display_name}"}
-    output PrivateKeyData {value = "${google_service_account_key.key.private_key}"}
-    output ProjectId {value = "${google_service_account.account.project}"}
-    output UniqueId {value = "${google_service_account.account.unique_id}"}
+    output "Email" {
+      value = google_service_account.account.email
+    }
+
+    output "Name" {
+      value = google_service_account.account.display_name
+    }
+
+    output "PrivateKeyData" {
+      value = google_service_account_key.key.private_key
+    }
+
+    output "ProjectId" {
+      value = google_service_account.account.project
+    }
+
+    output "UniqueId" {
+      value = google_service_account.account.unique_id
+    }
   outputs:
   - required: true
     field_name: Email


### PR DESCRIPTION
With terraform version 0.12 and greater, Hashicorp changed the configuration language from HCL to HCL 2.0 (see [HCL 2.0 Transition](https://github.com/hashicorp/hcl/wiki/HCL-2.0-Transition)).

This PR updates all service definitions to comply with the HCL2 syntax.
The templates have been upgraded using `terraform 0.12upgrade <HCL_FILE>`.

---
**Note:**
The GCP Service Broker does not yet support HCL2 syntax. I will create a separate PR in the GCP Service Broker Repository that adds HCL2-support.